### PR TITLE
Add links to footer and remove target blank

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -15,19 +15,20 @@ import WordmarkWhite from "../../assets/wordmark-w-only.svg"
             <a href="/download">Download for Desktop</a>
             <a href="/download/android">Download for Android</a>
             <a href="/download/ios">Download for iOS and iPadOS</a>
-            <a href="https://support.revolt.chat/">Support</a>
+            <a href="https://status.revolt.chat">Status</a>
+            <a href="https://support.revolt.chat">Support</a>
         </div>
         <div class="links">
             <span>Developers</span>
-            <a href="https://developers.revolt.chat/"
+            <a href="https://developers.revolt.chat"
                 >Documentation</a
             >
-            <a href="https://translate.revolt.chat/"
+            <a href="https://translate.revolt.chat"
                 >Help Translate</a
             >
-			<a href="https://github.com/revoltchat"
-			   >GitHub</a
-			>
+	    <a href="https://github.com/revoltchat"
+		>GitHub</a
+	    >
         </div>
         <div class="links">
             <span>Team</span>
@@ -42,7 +43,7 @@ import WordmarkWhite from "../../assets/wordmark-w-only.svg"
             <a href="https://bsky.app/profile/revolt.chat"
                 >Bluesky</a
             >
-			<a href="https://mastodon.social/@revoltchat">Mastodon</a>
+	    <a href="https://mastodon.social/@revoltchat">Mastodon</a>
             <a href="https://reddit.com/r/revoltchat">Reddit</a>
             <a href="https://rvlt.gg/Testers">Revolt Server</a>
         </div>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -15,32 +15,36 @@ import WordmarkWhite from "../../assets/wordmark-w-only.svg"
             <a href="/download">Download for Desktop</a>
             <a href="/download/android">Download for Android</a>
             <a href="/download/ios">Download for iOS and iPadOS</a>
-            <a href="https://support.revolt.chat/" target="_blank">Support</a>
+            <a href="https://support.revolt.chat/">Support</a>
         </div>
         <div class="links">
             <span>Developers</span>
-            <a href="https://developers.revolt.chat/" target="_blank"
+            <a href="https://developers.revolt.chat/"
                 >Documentation</a
             >
-            <a href="https://translate.revolt.chat/" target="_blank"
+            <a href="https://translate.revolt.chat/"
                 >Help Translate</a
             >
+			<a href="https://github.com/revoltchat"
+			   >GitHub</a
+			>
         </div>
         <div class="links">
             <span>Team</span>
             <a href="/about">About</a>
             <a href="/updates">Blog and Changelogs</a>
-            <a href="https://support.revolt.chat/contact" target="_blank"
+            <a href="https://support.revolt.chat/contact"
                 >Contact</a
             >
         </div>
         <div class="links">
             <span>Revolt on Socials</span>
-            <a href="https://bsky.app/profile/revolt.chat" target="_blank"
+            <a href="https://bsky.app/profile/revolt.chat"
                 >Bluesky</a
             >
-            <a href="https://reddit.com/r/revoltchat" target="_blank">Reddit</a>
-            <a href="https://rvlt.gg/Testers" target="_blank">Revolt Server</a>
+			<a href="https://mastodon.social/@revoltchat">Mastodon</a>
+            <a href="https://reddit.com/r/revoltchat">Reddit</a>
+            <a href="https://rvlt.gg/Testers">Revolt Server</a>
         </div>
         <div class="links">
             <span>Legal</span>

--- a/src/content/blog/a-fresh-coat-of-paint.md
+++ b/src/content/blog/a-fresh-coat-of-paint.md
@@ -13,7 +13,7 @@ Well, we can't help with those things, but what we can help with is telling you 
 
 Here's a full-page screenshot, because the researchers at Revolt R&D have determined that those are 2.34 times cooler than regular screenshots:
 
-<a href="/content/blog/a-fresh-coat-of-paint/fullpage.jpg" target="_blank" style="color:white;text-decoration:none;font-weight:550">
+<a href="/content/blog/a-fresh-coat-of-paint/fullpage.jpg" style="color:white;text-decoration:none;font-weight:550">
 <img src="/content/blog/a-fresh-coat-of-paint/fullpage.jpg" alt="Full page screenshot of the new Revolt marketing website" /><br/>
 <div style="text-align:center">View full size</div>
 </a>


### PR DESCRIPTION
- Removed all instances of `target="_blank"` as it has significant negative accessibility implications and prohibits users from opening a link in their current tab, even if they wish to
- Added Mastodon link
- Added GitHub link
- Added Status page link

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended
