### PR TITLE
Add RSS feeds

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import mdx from "@astrojs/mdx"
 
 // https://astro.build/config
 export default defineConfig({
+	site: "https://revolt.chat",
     output: "server",
     integrations: [solidJs(), mdx()],
     adapter: node({
@@ -43,6 +44,7 @@ export default defineConfig({
         },
         "/updates/100K-users": {
             // I! MEAN! IT!
+            // Okay, this one was on me, but you're the one who repeated my mistake in the 500K post Jen. - Vale
             status: 307,
             destination: "/updates/100k-users",
         },

--- a/deno.lock
+++ b/deno.lock
@@ -4,6 +4,7 @@
     "npm:@astrojs/check@~0.9.3": "0.9.4_typescript@5.7.3",
     "npm:@astrojs/mdx@^3.1.7": "3.1.9_astro@4.16.17__@babel+core@7.26.0__typescript@5.7.3__sass@1.83.4__vite@5.4.11___sass@1.83.4__zod@3.24.1_typescript@5.7.3_sass@1.83.4_acorn@8.14.0",
     "npm:@astrojs/node@^8.3.3": "8.3.4_astro@4.16.17__@babel+core@7.26.0__typescript@5.7.3__sass@1.83.4__vite@5.4.11___sass@1.83.4__zod@3.24.1_typescript@5.7.3_sass@1.83.4",
+    "npm:@astrojs/rss@^4.0.11": "4.0.11",
     "npm:@astrojs/solid-js@^4.4.1": "4.4.4_solid-js@1.9.4__seroval@1.2.1_sass@1.83.4_vite@5.4.11__sass@1.83.4",
     "npm:@fontsource/fragment-mono@^5.1.0": "5.1.1",
     "npm:astro@^4.14.5": "4.16.17_@babel+core@7.26.0_typescript@5.7.3_sass@1.83.4_vite@5.4.11__sass@1.83.4_zod@3.24.1",
@@ -116,6 +117,13 @@
       "integrity": "sha512-Z9IYjuXSArkAUx3N6xj6+Bnvx8OdUSHA8YoOgyepp3+zJmtVYJIl/I18GozdJVW1p5u/CNpl3Km7/gwTJK85cw==",
       "dependencies": [
         "prismjs"
+      ]
+    },
+    "@astrojs/rss@4.0.11": {
+      "integrity": "sha512-3e3H8i6kc97KGnn9iaZBJpIkdoQi8MmR5zH5R+dWsfCM44lLTszOqy1OBfGGxDt56mpQkYVtZJWoxMyWuUZBfw==",
+      "dependencies": [
+        "fast-xml-parser",
+        "kleur@4.1.5"
       ]
     },
     "@astrojs/solid-js@4.4.4_solid-js@1.9.4__seroval@1.2.1_sass@1.83.4_vite@5.4.11__sass@1.83.4": {
@@ -1521,6 +1529,12 @@
     },
     "fast-uri@3.0.3": {
       "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw=="
+    },
+    "fast-xml-parser@4.5.1": {
+      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+      "dependencies": [
+        "strnum"
+      ]
     },
     "fastq@1.18.0": {
       "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
@@ -3273,6 +3287,9 @@
     "strip-bom@3.0.0": {
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
     },
+    "strnum@1.0.5": {
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "style-to-object@0.4.4": {
       "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
       "dependencies": [
@@ -3728,6 +3745,7 @@
         "npm:@astrojs/check@~0.9.3",
         "npm:@astrojs/mdx@^3.1.7",
         "npm:@astrojs/node@^8.3.3",
+        "npm:@astrojs/rss@^4.0.11",
         "npm:@astrojs/solid-js@^4.4.1",
         "npm:@fontsource/fragment-mono@^5.1.0",
         "npm:astro@^4.14.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@astrojs/check": "^0.9.3",
     "@astrojs/mdx": "^3.1.7",
     "@astrojs/node": "^8.3.3",
+    "@astrojs/rss": "^4.0.11",
     "@astrojs/solid-js": "^4.4.1",
     "@fontsource/fragment-mono": "^5.1.0",
     "astro": "^4.14.5",

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -43,6 +43,8 @@ const {
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="generator" content={Astro.generator} />
+		<link rel="alternate" type="application/rss+xml" title="RSS feed of Revolt blog posts." href="https://revolt.chat/updates/blog-feed.xml">
+		<link rel="alternate" type="application/rss+xml" title="RSS feed of Revolt changelogs." href="https://revolt.chat/updates/changelog-feed.xml">
         <title>{htmlTitleOverride || `${title} - Revolt`}</title>
         <StyleConstants />
     </head>

--- a/src/layouts/LegalLayout.astro
+++ b/src/layouts/LegalLayout.astro
@@ -39,6 +39,8 @@ const {
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="generator" content={Astro.generator} />
+		<link rel="alternate" type="application/rss+xml" title="RSS feed of Revolt blog posts." href="https://revolt.chat/updates/blog-feed.xml">
+		<link rel="alternate" type="application/rss+xml" title="RSS feed of Revolt changelogs." href="https://revolt.chat/updates/changelog-feed.xml">
         <title>{htmlTitleOverride || `${title} - Revolt`}</title>
         <StyleConstants />
     </head>

--- a/src/layouts/MarketingLayout.astro
+++ b/src/layouts/MarketingLayout.astro
@@ -28,6 +28,8 @@ const { title, backgroundColor } = Astro.props
         <meta name="theme-color" content={COLOUR_ULTRA_PINK} />
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="alternate" type="application/rss+xml" title="RSS feed of Revolt blog posts." href="https://revolt.chat/updates/blog-feed.xml">
+		<link rel="alternate" type="application/rss+xml" title="RSS feed of Revolt changelogs." href="https://revolt.chat/updates/changelog-feed.xml">
         <meta name="generator" content={Astro.generator} />
         <title>{title}</title>
         <StyleConstants />

--- a/src/pages/updates/blog-feed.xml.js
+++ b/src/pages/updates/blog-feed.xml.js
@@ -1,0 +1,24 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+
+export async function GET(context) {
+	const blogEntries = (await getCollection("blog"))
+		.filter((entry) => entry.data.hidden !== true)
+		.toSorted((a, b) => {
+			return new Date(b.data.date).getTime() - new Date(a.data.date).getTime();
+		});
+	return rss({
+		title: "Revolt Blog",
+		description: "Feed of Revolt blog posts.",
+		site: context.site,
+		trailingSlash: false,
+		items: blogEntries.map((entry) => ({
+			title: entry.data.title,
+			pubDate: entry.data.date,
+			description: entry.data.description,
+			author: entry.data.author,
+			link: `/updates/${entry.slug}/`,
+		})),
+		customData: `<language>en-gb</language>`,
+	});
+}

--- a/src/pages/updates/changelog-feed.xml.js
+++ b/src/pages/updates/changelog-feed.xml.js
@@ -1,0 +1,22 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+
+export async function GET(context) {
+	const changelogEntries = (await getCollection("changelog")).toSorted((a, b) => {
+		return new Date(b.data.date).getTime() - new Date(a.data.date).getTime();
+	});
+	return rss({
+		title: "Revolt Changelog",
+		description: "Feed of Revolt changelogs.",
+		site: context.site,
+		trailingSlash: false,
+		items: changelogEntries.map((entry) => ({
+			title: entry.data.title,
+			pubDate: entry.data.date,
+			description: entry.data.description,
+			author: entry.data.author,
+			link: `/updates/${entry.slug}/`,
+		})),
+		customData: `<language>en-gb</language>`,
+	});
+}


### PR DESCRIPTION
Adds RSS feeds for blog posts and changelogs.

Accessible at `/updates/changelog-feed.xml` and `/updates/blog-feed.xml`.

Closes https://github.com/revoltchat/revolt.chat/issues/29

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended
