### PR TITLE
feat(download): add Aurora Store (FOSS) option for Android

### DIFF
--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -5,6 +5,8 @@ export default class Consts {
         "ms-windows-store://pdp/?ProductId=9nmtvmrj7n1k" as const;
     static readonly PLAYSTORE_URL =
         "https://play.google.com/store/apps/details?id=chat.revolt" as const;
+    static readonly AURORASTORE_URL =
+        "https://f-droid.org/packages/com.aurora.store/" as const;
     static readonly FLATHUB_URL =
         "https://flathub.org/apps/chat.revolt.RevoltDesktop" as const;
     static readonly TESTFLIGHT_URL =

--- a/src/pages/download/index.astro
+++ b/src/pages/download/index.astro
@@ -97,10 +97,15 @@ import Consts from "../../lib/consts";
             url: Consts.PLAYSTORE_URL,
             primary: true,
           },
+          {
+            name: "Aurora Store (FOSS)",
+            url: Consts.AURORASTORE_URL,
+            primary: false,
+          }
         ]}
       >
         <p slot="description" class="description">
-          Download Stoat for Android on the Google Play Store.<br />
+          Download Stoat for Android on the Google Play Store and Aurora Store.<br />
           Full tablet and foldable support included.<br />
           Android 8.0 and above.
         </p>


### PR DESCRIPTION
Since Stoat is also on the Aurora Store, I added Aurora as a download option on the site.

**Before:**
---
<img width="1228" height="522" alt="Screenshot 2026-01-25 at 9 15 38 AM" src="https://github.com/user-attachments/assets/5025127b-c9fc-449b-a615-bebbd5dc0e38" />

**After:**
---
<img width="1260" height="562" alt="Screenshot 2026-01-25 at 8 55 53 AM" src="https://github.com/user-attachments/assets/09683509-3f3e-4f2c-9007-a3d989837ff7" />
