### PR TITLE
docs(download): fix 'System Preferences' typo and add relaunch step

### DIFF
--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -5,6 +5,8 @@ export default class Consts {
         "ms-windows-store://pdp/?ProductId=9nmtvmrj7n1k" as const;
     static readonly PLAYSTORE_URL =
         "https://play.google.com/store/apps/details?id=chat.revolt" as const;
+    static readonly AURORASTORE_URL =
+        "https://f-droid.org/packages/com.aurora.store/" as const;
     static readonly FLATHUB_URL =
         "https://flathub.org/apps/chat.revolt.RevoltDesktop" as const;
     static readonly TESTFLIGHT_URL =

--- a/src/pages/download/index.astro
+++ b/src/pages/download/index.astro
@@ -61,11 +61,11 @@ import Consts from "../../lib/consts";
           Download Stoat for macOS.<br /><br />
           If you receive the error <strong
             >"Stoat" is damaged and can't be opened</strong
-          >: <br /> Open System Preference &gt; Privacy & Security then select "Open
+          >: <br /> Open System Preferences &gt; Privacy & Security then select "Open
           Anyway" for the app. If the option is not present, redownload the app,
           open the Terminal app using Spotlight, then paste <code
             >cd ~/Downloads && xattr -d com.apple.quarantine Stoat.app</code
-          > and press enter.
+          >, press Enter, then relaunch the app.
         </p>
       </DownloadTile>
       <DownloadTile

--- a/src/pages/download/index.astro
+++ b/src/pages/download/index.astro
@@ -97,10 +97,15 @@ import Consts from "../../lib/consts";
             url: Consts.PLAYSTORE_URL,
             primary: true,
           },
+          {
+            name: "Aurora Store (FOSS)",
+            url: Consts.AURORASTORE_URL,
+            primary: false,
+          }
         ]}
       >
         <p slot="description" class="description">
-          Download Stoat for Android on the Google Play Store.<br />
+          Download Stoat for Android on the Google Play Store and Aurora Store.<br />
           Full tablet and foldable support included.<br />
           Android 8.0 and above.
         </p>

--- a/src/pages/download/index.astro
+++ b/src/pages/download/index.astro
@@ -62,8 +62,8 @@ import Consts from "../../lib/consts";
           If you receive the error <strong
             >"Stoat" is damaged and can't be opened</strong
           >: <br /> Open System Preferences &gt; Privacy & Security then select "Open
-          Anyway" for the app. If the option is not present, redownload the app,
-          open the Terminal app using Spotlight, then paste <code
+          Anyway" for the app. If the option is not present, redownload the app, open
+          the Terminal app using Spotlight, then paste <code
             >cd ~/Downloads && xattr -d com.apple.quarantine Stoat.app</code
           >, press Enter, then relaunch the app.
         </p>
@@ -101,11 +101,12 @@ import Consts from "../../lib/consts";
             name: "Aurora Store (FOSS)",
             url: Consts.AURORASTORE_URL,
             primary: false,
-          }
+          },
         ]}
       >
         <p slot="description" class="description">
-          Download Stoat for Android on the Google Play Store and Aurora Store.<br />
+          Download Stoat for Android on the Google Play Store and Aurora Store.<br
+          />
           Full tablet and foldable support included.<br />
           Android 8.0 and above.
         </p>


### PR DESCRIPTION
- Fix "System Preference" typo to "System Preferences"
- Add explicit "relaunch app" instruction after quarantine command since app doesn't auto-relaunch