### PR TITLE
fix: Updated mentions of 'Revolt' to 'Stoat'

### DIFF
--- a/src/content/legal/community-guidelines.mdx
+++ b/src/content/legal/community-guidelines.mdx
@@ -1,12 +1,12 @@
 ---
 title: Community Guidelines
-description: Rules and guidelines that apply to all users, communities, and content on Revolt.
+description: Rules and guidelines that apply to all users, communities, and content on Stoat.
 showDescriptionOnPage: true
 ---
 
-_Last updated: 05. Feb, 2025_
+_Last updated: 11. Feb, 2025_
 
-**Revolt** can cater to your community, raid guild, study group, and anything in-between. We encourage you to:
+**Stoat** can cater to your community, raid guild, study group, and anything in-between. We encourage you to:
 
 -   Take advantage of our powerful community tools.
 -   Be kind and make friends with others on our platform.
@@ -57,7 +57,7 @@ To ensure users stay safe on the platform, we explicitly disallow:
 
 -   **Sharing any content that violates another person's intellectual property or other rights**
 
-    This includes any content that would violate the Digital Millennium Copyright Act (DMCA). We respond to DMCA requests as described in our [Terms of Service](https://revolt.chat/terms). This includes, but is not limited to, hacking, the cracking or distribution of pirated software, cheats, exploits, or hacks for our or another company, or person's service where it is forbidden.
+    This includes any content that would violate the Digital Millennium Copyright Act (DMCA). We respond to DMCA requests as described in our [Terms of Service](https://stoat.chat/legal/terms). This includes, but is not limited to, hacking, the cracking or distribution of pirated software, cheats, exploits, or hacks for our or another company, or person's service where it is forbidden.
 
 -   **Sharing any imagery that depicts real-life violence, gore, or animal cruelty**
 
@@ -91,9 +91,9 @@ To ensure users have equal opportunity to use the service and are not taken adva
 
     Any attempt to deceive users for financial gain, including phishing, multi level marketing, or other fraudulent activities.
 
--   **Buying and selling of Revolt accounts**
+-   **Buying and selling of Stoat accounts**
 
-    The transfer of Revolt accounts for monetary or other compensation is not permitted.
+    The transfer of Stoat accounts for monetary or other compensation is not permitted.
 
 -   **Selling, purchasing, or providing means to artificially grow servers**
 
@@ -105,11 +105,11 @@ To ensure users have equal opportunity to use the service and are not taken adva
 
 -   **Attempts to hack or otherwise gain unauthorised access to our service**
 
-    Any attempt to compromise the security of our platform or its users, including but not limited to phishing attacks, unauthorised access to user accounts, distribution or creation of malware, or Denial of Service attacks, is strictly forbidden. This also includes attempts to gain access to our backend networks. _Please contact us ahead of time for permission to test our networks by emailing [security@revolt.chat](mailto:security@revolt.chat)._
+    Any attempt to compromise the security of our platform or its users, including but not limited to phishing attacks, unauthorised access to user accounts, distribution or creation of malware, or Denial of Service attacks, is strictly forbidden. This also includes attempts to gain access to our backend networks. _Please contact us ahead of time for permission to test our networks by emailing [security@stoat.chat](mailto:security@stoat.chat)._
 
 -   **Abusing our server resources**
 
-    Using Revolt with malicious intent, in a way that is not reasonable under normal usage, in order to outsource computing and/or storage resources to our servers, as well as other forms of Denial of Service to our infrastructure.
+    Using Stoat with malicious intent, in a way that is not reasonable under normal usage, in order to outsource computing and/or storage resources to our servers, as well as other forms of Denial of Service to our infrastructure.
 
 -   **Automation of user actions**
 
@@ -125,13 +125,13 @@ To ensure users have equal opportunity to use the service and are not taken adva
 
 ## Reporting Violations
 
-To report any of the above activity, please use the in-app reporting system. If you cannot use the in-app reporting system for any reason, please contact us at [abuse@revolt.chat](mailto:abuse@revolt.chat).
+To report any of the above activity, please use the in-app reporting system. If you cannot use the in-app reporting system for any reason, please contact us at [abuse@stoat.chat](mailto:abuse@stoat.chat).
 
 ## Strikes and Suspensions
 
 Violations of these Community Guidelines, or other platform terms, may result in strikes against your account. Strikes are irreversible. Account suspensions can be removed through a successful appeal, but only if you believe that we took the wrong action. There is no point asking to be appealed for breaking the law.
 
-If you wish to appeal a suspension, please contact [abuse@revolt.chat](mailto:abuse@revolt.chat).
+If you wish to appeal a suspension, please contact [abuse@stoat.chat](mailto:abuse@stoat.chat).
 
 ## Off-Platform Behavior
 

--- a/src/content/legal/privacy.mdx
+++ b/src/content/legal/privacy.mdx
@@ -10,16 +10,16 @@ _Effective: 24. Mar, 2025_
 
 ### Introduction
 
-We get that legal documents can be overwhelming and boring, so we've tried our best to keep it as simple and possible while providing the information needed. It is important however to remember that these terms are legally binding between yourself and us if you choose to use Revolt, so please read them carefully before proceeding - We will continue to improve and tackle some sections.
+We get that legal documents can be overwhelming and boring, so we've tried our best to keep it as simple and possible while providing the information needed. It is important however to remember that these terms are legally binding between yourself and us if you choose to use Stoat, so please read them carefully before proceeding - We will continue to improve and tackle some sections.
 
 ### Your Privacy
 
 Your privacy is very important to us, and we will ensure protecting your privacy when using our services.
 
-**Revolt** is an open-source project (source code is available on our [GitHub](https://github.com/revoltchat)), and we respect our user's privacy while remaining transparent with our users. We only collect limited data from our users that is absolutely necessary.
+**Stoat** is an open-source project (source code is available on our [GitHub](https://github.com/stoatchat)), and we respect our user's privacy while remaining transparent with our users. We only collect limited data from our users that is absolutely necessary.
 
--   **Account Information**: We collect data from our users when they register for an account on Revolt, such as: the registered e-mail address, hashed password, and chosen username.
--   **Servers and Groups**: If you create or join a group/server on Revolt, we collect and store the names of the group/server to provide the service.
+-   **Account Information**: We collect data from our users when they register for an account on Stoat, such as: the registered e-mail address, hashed password, and chosen username.
+-   **Servers and Groups**: If you create or join a group/server on Stoat, we collect and store the names of the group/server to provide the service.
 -   **Your Content**: To provide the service, we must store your messages and any content such as attachments and reactions.
 -   **Legal Responsibility**: To ensure that users satisfy the legal age requirement to use the platform and to provide additional safety for minors, we must collect user's date of birth.
 -   **Abuse Prevention**: To prevent our service from being attacked and protect your account, we collect your IP address and a short device description for each session, and also temporarily store some device information after initial registration.
@@ -29,7 +29,7 @@ Your privacy is very important to us, and we will ensure protecting your privacy
 
 We will NEVER sell your data to any third-parties, although we use certain service providers to process your data, such as:
 
--   [Hetzner](https://hetzner.com), provides us with cloud services to run Revolt.
+-   [Hetzner](https://hetzner.com), provides us with cloud services to run Stoat.
 -   [Backblaze](https://backblaze.com), provides us with cloud services to store media at scale.
 -   [hCaptcha](https://hcaptcha.com), provides us with the tools necessary to stop abuse of our platform. [See footnote.](#hcaptcha)
 -   [Cloudflare](https://cloudflare.com), provides us with DDoS mitigation and content delivery acceleration.
@@ -40,7 +40,7 @@ _Law & Order: We may disclose your information to third parties only if such dis
 
 Your information is stored on servers provided by cloud providers within the European Union, however information may also be stored within the United Kingdom in the form of encrypted backups or when required to operate the service.
 
-If you wish to request deletion of any information stored on our servers, including any requests under GDPR or DMCA, please use the account deletion / reporting in-app if possible or otherwise contact us at [urgent@revolt.chat](mailto:urgent@revolt.chat).
+If you wish to request deletion of any information stored on our servers, including any requests under GDPR or DMCA, please use the account deletion / reporting in-app if possible or otherwise contact us at [urgent@stoat.chat](mailto:urgent@stoat.chat).
 
 _Exceptions to third-parties service providers which is used to process your data as mentioned above._
 
@@ -48,17 +48,17 @@ _Exceptions to third-parties service providers which is used to process your dat
 
 We abide by [the children's consent guidelines as laid out by the GDPR](https://gdpr-info.eu/art-8-gdpr/) and [The Children’s Online Privacy Protection Act (“COPPA”)](https://www.ftc.gov/enforcement/rules/rulemaking-regulatory-reform-proceedings/childrens-online-privacy-protection-rule), which requires online service providers to obtain parental consent before they knowingly collect personally identifiable information online from children who are under 16 and 13 years of age respectively, and in the case of the GDPR, may vary depending on the EU member state.
 
-We do not knowingly collect or solicit personally identifiable information from children under the minimum legal age to use the service. If we learn we have collected personal information from a child under the minimum legal age to use the service, we will immediately delete that information from our servers. If you are a parent or guardian of a child under the age and believe that they have disclosed personal information to us, please contact us at [contact@revolt.chat](mailto:contact@revolt.chat). As a concerned user of the platform, you may also report underage users by using the in-app report feature.
+We do not knowingly collect or solicit personally identifiable information from children under the minimum legal age to use the service. If we learn we have collected personal information from a child under the minimum legal age to use the service, we will immediately delete that information from our servers. If you are a parent or guardian of a child under the age and believe that they have disclosed personal information to us, please contact us at [contact@stoat.chat](mailto:contact@stoat.chat). As a concerned user of the platform, you may also report underage users by using the in-app report feature.
 
 ### Your rights under the GDPR
 
-The data controller of your personal data is Pawel Makles. You can contact him at [dpo@revolt.chat](mailto:dpo@revolt.chat). The data controller is responsible for deciding how and why we process your personal data.
+The data controller of your personal data is Pawel Makles. You can contact him at [dpo@stoat.chat](mailto:dpo@stoat.chat). The data controller is responsible for deciding how and why we process your personal data.
 
-The legal basis for processing your personal data is based on your consent, which you give us when you sign up for Revolt and agree to our Terms of Service and Privacy Policy. You can withdraw your consent at any time by deleting your account or contacting us. We may also process your personal data to comply with our legal obligations, to protect our legitimate interests or the interests of others.
+The legal basis for processing your personal data is based on your consent, which you give us when you sign up for Stoat and agree to our Terms of Service and Privacy Policy. You can withdraw your consent at any time by deleting your account or contacting us. We may also process your personal data to comply with our legal obligations, to protect our legitimate interests or the interests of others.
 
 As a user of our service, you have the right to lodge a complaint under the UK General Data Protection Regulation (UK GDPR) if you think that we have mishandled your personal data or violated your data protection rights. You can do this by contacting us directly and explaining your concerns. If you are not satisfied with our response, you can also escalate your complaint to the Information Commissioner's Office (ICO), which is the supervisory authority for UK GDPR. You can find more information about how to make a data protection complaint on their website.
 
-Currently, you may request a copy of all of your data by contacting us at [contact@revolt.chat](mailto:contact@revolt.chat).
+Currently, you may request a copy of all of your data by contacting us at [contact@stoat.chat](mailto:contact@stoat.chat).
 
 ### Changes to our Privacy Policy
 
@@ -68,7 +68,7 @@ You are advised to review our Privacy Policy periodically for any changes. Such 
 
 ### Contact Us
 
-Feel free to contact us if you have any questions regarding this Privacy Policy or any of the above statements. You may contact us by emailing [contact@revolt.chat](mailto:contact@revolt.chat).
+Feel free to contact us if you have any questions regarding this Privacy Policy or any of the above statements. You may contact us by emailing [contact@stoat.chat](mailto:contact@stoat.chat).
 
 ### hCaptcha
 
@@ -76,7 +76,7 @@ Feel free to contact us if you have any questions regarding this Privacy Policy 
 
 We use the hCaptcha anti-bot service (hereinafter "hCaptcha") on our website. This service is provided by Intuition Machines, Inc., a Delaware US Corporation ("IMI"). hCaptcha is used to check whether the data entered on our website (such as on a login page or contact form) has been entered by a human or by an automated program. To do this, hCaptcha analyzes the behavior of the website or mobile app visitor based on various characteristics. This analysis starts automatically as soon as the website or mobile app visitor enters a part of the website or app with hCaptcha enabled.
 
-When using the [Revolt App](https://app.revolt.chat), hCaptcha will only begin analysis when you:
+When using the [Stoat App](https://stoat.chat/app), hCaptcha will only begin analysis when you:
 
 -   Submit a login request.
 -   Submit a registration request.

--- a/src/content/legal/terms.mdx
+++ b/src/content/legal/terms.mdx
@@ -1,6 +1,6 @@
 ---
 title: Terms of Service
-description: Legally binding document describing the contractual relationship between Revolt and its users.
+description: Legally binding document describing the contractual relationship between Stoat and its users.
 showDescriptionOnPage: false
 ---
 
@@ -10,7 +10,7 @@ _Effective: 24. Mar, 2025_
 
 ### **Introduction**
 
-We get that legal documents can be overwhelming and boring, so we've tried our best to keep it as simple and possible while providing the information needed. It is important however to remember that these terms are legally binding between yourself and us if you choose to use Revolt, so please read them carefully before proceeding - We will continue to improve and tackle some sections.
+We get that legal documents can be overwhelming and boring, so we've tried our best to keep it as simple and possible while providing the information needed. It is important however to remember that these terms are legally binding between yourself and us if you choose to use Stoat, so please read them carefully before proceeding - We will continue to improve and tackle some sections.
 
 ### Definitions
 
@@ -19,19 +19,19 @@ Throughout this document, we will use certain terminology to refer to things spe
 -   **Terms** – the Terms of Service, a legally binding agreement between Us and You ("Terms", "Terms of Service")
 -   **You** – the user ("you", "your" or "user")
 -   **Revolt Platforms Ltd** – the company providing the service ("us", "we", "our")
--   **Revolt** – the service provided by us ("Revolt", "Platform", "Service" or "Application")
+-   **Stoat** – the service provided by us ("Stoat", "Platform", "Service" or "Application")
 
 Your access to and use of the service is conditioned on your acceptance of and compliance with these Terms. These Terms apply to all visitors, users and others who access or use our services. By accessing or using the service you agree to be bound by these Terms. If you disagree with any part of the terms, then please discontinue the use of this service.
 
 ### **Understanding what we are**
 
-Revolt is a chat application that allows you to communicate with other users through instant messaging, voice or video calls. Some content shared on the platform may lead to external websites that are not hosted by us. See [5. Other linked websites](#5-other-linked-websites).
+Stoat is a chat application that allows you to communicate with other users through instant messaging, voice or video calls. Some content shared on the platform may lead to external websites that are not hosted by us. See [5. Other linked websites](#5-other-linked-websites).
 
 **By using our Service, you agree:**
 
 -   You are of the minimum age to use the service, [we maintain a list of age requirements here](https://support.revolt.chat/kb/safety/minimum-age-guidelines).
 -   You have read and understood the Terms and Privacy Policy.
--   You agree to abide by our [Community Guidelines](https://revolt.chat/aup).
+-   You agree to abide by our [Community Guidelines](https://stoat.chat/legal/community-guidelines).
 
 The Terms are subject to change at any time, we will always notify you an adequate amount of time in advance when we make changes.
 
@@ -49,7 +49,7 @@ We may terminate or suspend access to our services immediately, without prior no
 
 ## 3. Community Guidelines
 
-Our current community guidelines can be found here: https://revolt.chat/aup
+Our current community guidelines can be found here: https://stoat.chat/legal/community-guidelines
 
 ## 4. Content
 
@@ -63,7 +63,7 @@ We have no control over and assume no responsibility for the content, privacy po
 
 ## 6. Warranty
 
-Revolt is provided "as is" with no warranty and/or liability for any outcomes of using our service. Revolt is not responsible for any content shared on self-hosted instances.
+Stoat is provided "as is" with no warranty and/or liability for any outcomes of using our service. Stoat is not responsible for any content shared on self-hosted instances.
 
 ## 7. Changes
 
@@ -73,4 +73,4 @@ You are advised to review our Terms of Service periodically for any changes. Cha
 
 ## Contact Us
 
-Feel free to contact us if you have any questions regarding our Terms of Service or any of the above statements. You may contact us as follows: [contact@revolt.chat](mailto:contact@revolt.chat)
+Feel free to contact us if you have any questions regarding our Terms of Service or any of the above statements. You may contact us as follows: [contact@stoat.chat](mailto:contact@stoat.chat)


### PR DESCRIPTION
I'm pretty certain I got all the mentions of "Revolt" minus the legally necessary ones

I checked the links to ensure I had the correct ones, but it's worth having a second set of eyes